### PR TITLE
Add a social option to project discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Multiple choice.
 * Bitbucket
 * SourceForge
 * DailyJS
+* Twitter / IRC / Asking friends
 
 ### Project Hosting: Preferred hosting for your own JavaScript projects
 


### PR DESCRIPTION
Asking people you know on twitter / IRC / whatever is a common way to find modules that do one thing well.
