### PR TITLE
Added browserify cdn to CDN question

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Multiple choice.
 * jQuery CDN
 * CloudFlare
 * MaxCDN
+* Browserify CDN / wzrd.in
 * Other
 
 ### Other than JavaScript, what are your primary development languages?


### PR DESCRIPTION
browserify cdn is a way to request any module from npm through a CDN.

One is hosted at http://wzrd.in/
